### PR TITLE
[rpc]blindrawtransaction accepts more commitments

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5759,8 +5759,8 @@ UniValue blindrawtransaction(const JSONRPCRequest& request)
     std::vector<std::vector<unsigned char> > auxiliary_generators;
     if (request.params.size() > 2) {
         UniValue assetCommitments = request.params[2].get_array();
-        if (assetCommitments.size() != 0 && assetCommitments.size() != tx.vin.size()) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Asset commitment array must have exactly as many entries as transaction inputs.");
+        if (assetCommitments.size() != 0 && assetCommitments.size() < tx.vin.size()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Asset commitment array must have at least as many entries as transaction inputs.");
         }
         for (size_t nIn = 0; nIn < assetCommitments.size(); nIn++) {
             if (assetCommitments[nIn].isStr()) {

--- a/test/functional/feature_confidential_transactions.py
+++ b/test/functional/feature_confidential_transactions.py
@@ -496,11 +496,11 @@ class CTTest (BitcoinTestFramework):
 
         # Create one part of the transaction to partially blind
         rawtx = self.nodes[0].createrawtransaction(
-            inputs, {dst_addr2: Decimal("0.01")})
+            inputs[:1], {dst_addr2: Decimal("0.01")})
 
         # Create another part of the transaction to partially blind
         rawtx2 = self.nodes[0].createrawtransaction(
-            inputs,
+            inputs[1:],
             {dst_addr: Decimal("0.1"), dst_addr3: Decimal("1.0")},
             0,
             False,
@@ -523,13 +523,13 @@ class CTTest (BitcoinTestFramework):
         # Combine the transactions
 
         # Blinded, but incomplete transaction.
-        # 3 inputs and 1 output, but no fee output, and
+        # 1 inputs and 1 output, but no fee output, and
         # it was blinded with 3 asset commitments, that means
         # the final transaction should have 3 inputs.
         btx = CTransaction()
         btx.deserialize(io.BytesIO(hex_str_to_bytes(blindtx)))
 
-        # Unblinded transaction, with 3 inputs and 2 outputs.
+        # Unblinded transaction, with 2 inputs and 2 outputs.
         # We will add them to the other transaction to make it complete.
         ubtx = CTransaction()
         ubtx.deserialize(io.BytesIO(hex_str_to_bytes(rawtx2)))
@@ -538,9 +538,11 @@ class CTTest (BitcoinTestFramework):
         # on top of inputs and outputs of the blinded, but incomplete transaction.
         # We also append empty witness instances to make witness arrays match
         # vin/vout arrays
+        btx.vin.append(ubtx.vin[0])
         btx.wit.vtxinwit.append(CTxInWitness())
         btx.vout.append(ubtx.vout[0])
         btx.wit.vtxoutwit.append(CTxOutWitness())
+        btx.vin.append(ubtx.vin[1])
         btx.wit.vtxinwit.append(CTxInWitness())
         btx.vout.append(ubtx.vout[1])
         btx.wit.vtxoutwit.append(CTxOutWitness())


### PR DESCRIPTION
masterのblindrawtransactionはcommitmentの数とblind対象のtransactionのinputの数が一致する必要がある。
しかし例えばconfidential asset demo はpartial blinding を使用するが、
e14 では blindrawtransaction のcommitmentは最終的なinputの数を用意して引き渡していた。

このPRはe14と同様の動作に戻したい。

参考： #510 #550